### PR TITLE
Fix plugin name in example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This plugin replaces calls to `Object.entries()` and `Object.values()` with call
 ## Example `.babelrc` configuration
 ```
 {
-  "plugins": ["babel-plugin-transform-object-entries"]
+  "plugins": ["transform-es2017-object-entries"]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-transform-es2017-object-entries",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Babel plugin for transforming ES2017 features Object.entries and Object.keys",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
Good morning,
and thanks for your plugin.

Previous example `.babelrc` configuration lead to an error: 
```
Uncaught Error: Module build failed: ReferenceError: Unknown plugin "babel-plugin-transform-object-entries"
```

Also, you [can omit](https://babeljs.io/docs/plugins/#plugin-preset-paths-plugin-preset-shorthand) "babel-plugin" part in the name.